### PR TITLE
Add speech-based levels and word list

### DIFF
--- a/baby_words.py
+++ b/baby_words.py
@@ -1,0 +1,12 @@
+BABY_WORDS = [
+    "mama", "dada", "ball", "dog", "cat", "milk", "book", "car", "hat", "shoe",
+    "apple", "banana", "cookie", "juice", "bird", "fish", "sun", "moon", "star", "rain",
+    "tree", "flower", "leaf", "grass", "water", "bath", "bed", "blanket", "hug", "kiss",
+    "no", "yes", "up", "down", "open", "close", "more", "gone", "please",
+    "thank", "you", "happy", "sad", "big", "small", "hot", "cold", "fast", "slow",
+    "red", "blue", "green", "yellow", "purple", "orange", "black", "white", "one", "two",
+    "three", "four", "five", "six", "seven", "eight", "nine", "ten", "jump", "run",
+    "walk", "sit", "stand", "sleep", "eat", "drink", "play", "toy", "block", "balloon",
+    "music", "song", "dance", "laugh", "cry", "hello", "bye", "night", "day", "ear",
+    "eye", "nose", "mouth", "hand", "foot", "tummy", "heart", "pillow", "chair", "table", "door"
+]

--- a/game/detectors.py
+++ b/game/detectors.py
@@ -2,6 +2,12 @@ import mediapipe as mp
 from math import acos, degrees
 from .utils import DetectorResult, normDist, getLmk, faceShoulderScales, GestureState
 
+# Optional speech recognition for sound-based levels
+try:
+    import speech_recognition as sr
+except Exception:  # library or microphone may be unavailable
+    sr = None
+
 mpHolistic = mp.solutions.holistic
 
 # ---------------- Finger counting ----------------
@@ -65,6 +71,9 @@ def friendlyLabel(move: str) -> str:
         inner = move[6:-1].split(";")[0]
         parts = [p.strip() for p in inner.split("+")]
         return "Combo: " + " → ".join(parts)
+    if move.startswith("SAY_"):
+        word = move.split("_", 1)[1].lower()
+        return f'Say "{word}" 🗣️'
     return FRIENDLY.get(move, move)
 
 # Back-compat alias for engine that calls friendly_label
@@ -210,6 +219,28 @@ def fingersBoth(expectedCount: int):
         return DetectorResult(False, f"Hands show L:{leftCount} R:{rightCount}, need {expectedCount}+{expectedCount}")
     return _fn
 
+def sayWord(expected: str):
+    """Return a detector that succeeds when the expected word is spoken."""
+    expected = expected.lower()
+
+    def _fn(poseLandmarks, gestureState: GestureState, now: float, settings, **_):
+        if sr is None:
+            return DetectorResult(False, "Speech recognition unavailable")
+        recognizer = sr.Recognizer()
+        try:
+            with sr.Microphone() as source:
+                recognizer.adjust_for_ambient_noise(source, duration=0.1)
+                audio = recognizer.listen(source, phrase_time_limit=2)
+            said = recognizer.recognize_google(audio).lower()
+        except Exception:
+            said = ""
+        ok = expected in said.split()
+        if ok:
+            return DetectorResult(True)
+        return DetectorResult(False, f"Say '{expected}'")
+
+    return _fn
+
 # ---------------- Registry ----------------
 
 def resolve_detector(move: str):
@@ -227,5 +258,8 @@ def resolve_detector(move: str):
         n = int(move.split("_")[-1]); return fingersRight(n), {"needs_hands": True}
     if move.startswith("FINGERS_BOTH_"):
         n = int(move.split("_")[-1]); return fingersBoth(n), {"needs_hands": True}
+    if move.startswith("SAY_"):
+        word = move.split("_", 1)[1]
+        return sayWord(word), {"needs_hands": False}
 
     return (lambda *a, **k: DetectorResult(False, "Unknown move")), {"needs_hands": False}

--- a/game/engine.py
+++ b/game/engine.py
@@ -13,7 +13,8 @@ mpStyles = mp.solutions.drawing_styles
 
 POOL_MOVES = [
     "HANDS_UP","CLAP","WAVE_RIGHT","WAVE_LEFT","JUMP","NOD","SHAKE_HEAD",
-    "FINGERS_L_2","FINGERS_R_5","FINGERS_BOTH_3"
+    "FINGERS_L_2","FINGERS_R_5","FINGERS_BOTH_3",
+    "SAY_MAMA","SAY_DADA"
 ]
 
 def load_levels(path: str):

--- a/levels.json
+++ b/levels.json
@@ -30,5 +30,13 @@
       "COMBO[HANDS_UP+CLAP+JUMP;T=7]",
       "COMBO[FINGERS_BOTH_3+WAVE_LEFT;T=8]"
     ]
+  },
+  {
+    "name": "Speak",
+    "moves": [
+      "SAY_MAMA",
+      "SAY_DADA",
+      "SAY_BALL"
+    ]
   }
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mediapipe==0.10.14
 opencv-python
 pygame
+SpeechRecognition


### PR DESCRIPTION
## Summary
- add detector support for SAY_<word> gestures using speech recognition
- include new "Speak" level and sample SAY_ moves in endless mode
- provide 100 baby-friendly words and document SpeechRecognition dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6899a7e7df248325be5ec7d40fff499e